### PR TITLE
Basic Fuzzy Matching Pull Request

### DIFF
--- a/src/com/lucidworks/analysis/AutoPhrasingTokenFilter.java
+++ b/src/com/lucidworks/analysis/AutoPhrasingTokenFilter.java
@@ -189,9 +189,14 @@ public final class AutoPhrasingTokenFilter extends TokenFilter {
             }
 
         } else {
-            if (CharArrayUtil.equals(potentialPhraseWords.get(0).toCharArray(), unusedTokens.get(0)))
-                return matches(potentialPhraseWords.subList(1, potentialPhraseWords.size()), unusedTokens.subList(1, unusedTokens.size())) + 1;
-            else
+            if (CharArrayUtil.equals(potentialPhraseWords.get(0).toCharArray(), unusedTokens.get(0))) {
+                int response = matches(potentialPhraseWords.subList(1, potentialPhraseWords.size()), unusedTokens.subList(1, unusedTokens.size()));
+                if (response == -1)
+                    return -1;
+                else
+                    return response + 1;
+
+            } else
                 return -1;
         }
 

--- a/src/com/lucidworks/analysis/AutoPhrasingTokenFilter.java
+++ b/src/com/lucidworks/analysis/AutoPhrasingTokenFilter.java
@@ -166,7 +166,7 @@ public final class AutoPhrasingTokenFilter extends TokenFilter {
         }
         if (phraseMatch != null) {
             LazyLog.logDebug("Found phrase match for '%s'.", phraseMatch);
-            for (int i=0; i<phraseWordsUsed; i++) {
+            for (int i=0; i<phraseWordsUsed && unusedTokens.size() > 0; i++) {
                 unusedTokens.remove(0);
             }
 

--- a/src/com/lucidworks/analysis/AutoPhrasingTokenFilter.java
+++ b/src/com/lucidworks/analysis/AutoPhrasingTokenFilter.java
@@ -121,7 +121,7 @@ public final class AutoPhrasingTokenFilter extends TokenFilter {
             //Figure out how many TOKEN options are present, since we these are all optional
             int tokenCount = 0;
             for (int i=0; i<potentialPhraseWords.length; i++) {
-                if ("TOKEN".equals(potentialPhraseWords[i])) {
+                if ("TOKEN?".equalsIgnoreCase(potentialPhraseWords[i])) {
                     tokenCount++;
                 }
             }
@@ -136,11 +136,11 @@ public final class AutoPhrasingTokenFilter extends TokenFilter {
             for (int i = 0 ; i < unusedTokens.size() && i < potentialPhraseWords.length  ; ++i) {
                 //If our potential match is "TOKEN", then we need to see if it matches the next "real" word, or
                 //not.  If it does, then continue from the "real" one.  If not, then go with the generic "TOKEN."
-                if ("TOKEN".equals(potentialPhraseWords[i])) {
+                if ("TOKEN?".equalsIgnoreCase(potentialPhraseWords[i])) {
                     String nextRealPotentialPhraseWord = "";
                     int j=i+1;
                     for (; j < potentialPhraseWords.length; j++) {
-                        if (!"TOKEN".equals(potentialPhraseWords[j])) {
+                        if (!"TOKEN?".equalsIgnoreCase(potentialPhraseWords[j])) {
                             nextRealPotentialPhraseWord = potentialPhraseWords[j];
                             break;
                         }
@@ -157,7 +157,7 @@ public final class AutoPhrasingTokenFilter extends TokenFilter {
                 }
             }
             if (matches && (phraseMatch == null || potentialPhraseWordsUsed > phraseWordsUsed)) {
-                potentialPhraseMatch = String.valueOf(potentialPhraseMatch).replaceAll("TOKEN ", "").toCharArray();
+                potentialPhraseMatch = String.valueOf(potentialPhraseMatch).replaceAll("[tT][oO][kK][eE][nN]\\? ", "").toCharArray();
                 LazyLog.logDebug("Found potential longest phrase match for '%s'.", potentialPhraseMatch);
                 phraseMatch = new char[potentialPhraseMatch.length];
                 arraycopy(potentialPhraseMatch, 0, phraseMatch, 0, potentialPhraseMatch.length);

--- a/src/com/lucidworks/analysis/AutoPhrasingTokenFilter.java
+++ b/src/com/lucidworks/analysis/AutoPhrasingTokenFilter.java
@@ -181,10 +181,12 @@ public final class AutoPhrasingTokenFilter extends TokenFilter {
             int option1 = matches(potentialPhraseWords.subList(1, potentialPhraseWords.size()), unusedTokens);
             //Option 2 is that the TOKEN? consumes something in the unused Tokens list
             int option2 = matches(potentialPhraseWords.subList(1, potentialPhraseWords.size()), unusedTokens.subList(1, unusedTokens.size()));
-            if (option1 < 0 && option2 < 0)
+            if (option1 < 0 && option2 < 0) {
                 return -1;
-            else
-                return option1 > option2 ? option1 + 1 : option2 + 1;
+            } else {
+                //Option 1 is that TOKEN? is skipped, so we don't increment the number of tokens "consumed" if we use Option 1.
+                return option1 > option2 ? option1 : option2 + 1;
+            }
 
         } else {
             if (CharArrayUtil.equals(potentialPhraseWords.get(0).toCharArray(), unusedTokens.get(0)))

--- a/test/com/lucidworks/analysis/TestAutoPhrasingQParserPlugin.java
+++ b/test/com/lucidworks/analysis/TestAutoPhrasingQParserPlugin.java
@@ -237,6 +237,24 @@ public class TestAutoPhrasingQParserPlugin extends TestCase {
         invokeCreateParser(actual, expected, DefaultIgnoreCase, EmptyReplaceWhitespaceWith);
     }
 
+    public void testBasicFuzzyMatchInQuery() throws Exception {
+        String actual = "one or two";
+        String expected = "onetwo";
+        invokeCreateParser(actual, expected, DefaultIgnoreCase, EmptyReplaceWhitespaceWith);
+    }
+
+    public void testBasicFuzzyMatchTokenOptionalInQuery() throws Exception {
+        String actual = "one two";
+        String expected = "onetwo";
+        invokeCreateParser(actual, expected, DefaultIgnoreCase, EmptyReplaceWhitespaceWith);
+    }
+
+    public void testFuzzyMatchDoesNotConsumeMetacharacters() throws Exception {
+        String expected = "one: two";
+        invokeCreateParser("one : two", expected, DefaultIgnoreCase, EmptyReplaceWhitespaceWith);
+        invokeCreateParser("one: two", expected, DefaultIgnoreCase, EmptyReplaceWhitespaceWith);
+    }
+
     public void test60Cc() throws Exception {
         String actual = "60 cc";
         String expected = "60cc";
@@ -396,6 +414,7 @@ public class TestAutoPhrasingQParserPlugin extends TestCase {
         phrases.add("more than one space");
         phrases.add("dup licate");
         phrases.add("dup licate");
+        phrases.add("one TOKEN? two");
         return phrases;
     }
 

--- a/test/com/lucidworks/analysis/TestAutoPhrasingQParserPlugin.java
+++ b/test/com/lucidworks/analysis/TestAutoPhrasingQParserPlugin.java
@@ -249,6 +249,18 @@ public class TestAutoPhrasingQParserPlugin extends TestCase {
         invokeCreateParser(actual, expected, DefaultIgnoreCase, EmptyReplaceWhitespaceWith);
     }
 
+    public void testDontEatParenthesis() throws Exception {
+        String actual = "q=( field: wheel chair )";
+        String expected = "q=(field: wheelchair)";
+        invokeCreateParser(actual, expected, DefaultIgnoreCase, EmptyReplaceWhitespaceWith);
+    }
+
+    public void testDontEatParenthesisFuzzyMatching() throws Exception {
+        String actual = "q=( field: one two )";
+        String expected = "q=(field: onetwo)";
+        invokeCreateParser(actual, expected, DefaultIgnoreCase, EmptyReplaceWhitespaceWith);
+    }
+
     public void testFuzzyMatchDoesNotConsumeMetacharacters() throws Exception {
         String expected = "one: two";
         invokeCreateParser("one : two", expected, DefaultIgnoreCase, EmptyReplaceWhitespaceWith);

--- a/test/com/lucidworks/analysis/TestAutoPhrasingTokenFilter.java
+++ b/test/com/lucidworks/analysis/TestAutoPhrasingTokenFilter.java
@@ -409,7 +409,7 @@ public class TestAutoPhrasingTokenFilter extends BaseTokenStreamTestCase {
     }
 
     public void testFuzzyMatchingMultipleTokens() throws Exception {
-        final CharArraySet phrases = getPhraseSets("corn TOKEN TOKEN bread");
+        final CharArraySet phrases = getPhraseSets("corn TOKEN? TOKEN? bread");
         final String input = "corn on my bread";
 
         Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
@@ -421,7 +421,7 @@ public class TestAutoPhrasingTokenFilter extends BaseTokenStreamTestCase {
     }
 
     public void testFuzzyMatchingSingleToken() throws Exception {
-        final CharArraySet phrases = getPhraseSets("corn TOKEN bread");
+        final CharArraySet phrases = getPhraseSets("corn TOKEN? bread");
         final String input = "corn or bread";
 
         Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
@@ -433,7 +433,7 @@ public class TestAutoPhrasingTokenFilter extends BaseTokenStreamTestCase {
     }
 
     public void testFuzzyMatchingTokenOptional() throws Exception {
-        final CharArraySet phrases = getPhraseSets("corn TOKEN bread");
+        final CharArraySet phrases = getPhraseSets("corn TOKEN? bread");
         final String input = "corn bread";
 
         Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
@@ -445,7 +445,7 @@ public class TestAutoPhrasingTokenFilter extends BaseTokenStreamTestCase {
     }
 
     public void testFuzzyMatchingTokenWithMultipleWordsAfter() throws Exception {
-        final CharArraySet phrases = getPhraseSets("first TOKEN second third");
+        final CharArraySet phrases = getPhraseSets("first TOKEN? second third");
         final String input = "first or second third";
 
         Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
@@ -457,7 +457,7 @@ public class TestAutoPhrasingTokenFilter extends BaseTokenStreamTestCase {
     }
 
     public void testFuzzyMatchingOptionalTokenWithMultipleWordsAfter() throws Exception {
-        final CharArraySet phrases = getPhraseSets("first TOKEN second third");
+        final CharArraySet phrases = getPhraseSets("first TOKEN? second third");
         final String input = "first second third";
 
         Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);

--- a/test/com/lucidworks/analysis/TestAutoPhrasingTokenFilter.java
+++ b/test/com/lucidworks/analysis/TestAutoPhrasingTokenFilter.java
@@ -468,4 +468,16 @@ public class TestAutoPhrasingTokenFilter extends BaseTokenStreamTestCase {
                 new int[] {1});
     }
 
+    public void testFuzzyMatchingDoesNotPrematurelyEnd() throws Exception {
+        final CharArraySet phrases = getPhraseSets("first TOKEN? TOKEN? TOKEN? second");
+        final String input = "first third fourth fifth";
+        Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
+        assertAnalyzesTo(analyzer, input,
+                new String[] {"first", "third", "fourth", "fifth"},
+                new int[] {0, 6, 12, 19},
+                new int[] {5, 11, 18, 24},
+                new int[] {1, 1, 1, 1});
+
+    }
+
 }

--- a/test/com/lucidworks/analysis/TestAutoPhrasingTokenFilter.java
+++ b/test/com/lucidworks/analysis/TestAutoPhrasingTokenFilter.java
@@ -480,4 +480,16 @@ public class TestAutoPhrasingTokenFilter extends BaseTokenStreamTestCase {
 
     }
 
+    public void testEarlyMatchesDoNotOverrideChanges() throws Exception {
+        final CharArraySet phrases = getPhraseSets("one two three");
+        final String input = "one two four";
+        Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
+        assertAnalyzesTo(analyzer, input,
+                new String[] {"one", "two", "four"},
+                new int[] {0, 4, 8},
+                new int[] {3, 7, 12},
+                new int[] {1, 1, 1});
+
+    }
+
 }

--- a/test/com/lucidworks/analysis/TestAutoPhrasingTokenFilter.java
+++ b/test/com/lucidworks/analysis/TestAutoPhrasingTokenFilter.java
@@ -407,4 +407,65 @@ public class TestAutoPhrasingTokenFilter extends BaseTokenStreamTestCase {
                 new int[] {17},
                 new int[] {1});
     }
+
+    public void testFuzzyMatchingMultipleTokens() throws Exception {
+        final CharArraySet phrases = getPhraseSets("corn TOKEN TOKEN bread");
+        final String input = "corn on my bread";
+
+        Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
+        assertAnalyzesTo(analyzer, input,
+                new String[] {"cornbread"},
+                new int[] {0},
+                new int[] {9},
+                new int[] {1});
+    }
+
+    public void testFuzzyMatchingSingleToken() throws Exception {
+        final CharArraySet phrases = getPhraseSets("corn TOKEN bread");
+        final String input = "corn or bread";
+
+        Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
+        assertAnalyzesTo(analyzer, input,
+                new String[] {"cornbread"},
+                new int[] {0},
+                new int[] {9},
+                new int[] {1});
+    }
+
+    public void testFuzzyMatchingTokenOptional() throws Exception {
+        final CharArraySet phrases = getPhraseSets("corn TOKEN bread");
+        final String input = "corn bread";
+
+        Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
+        assertAnalyzesTo(analyzer, input,
+                new String[] {"cornbread"},
+                new int[] {0},
+                new int[] {9},
+                new int[] {1});
+    }
+
+    public void testFuzzyMatchingTokenWithMultipleWordsAfter() throws Exception {
+        final CharArraySet phrases = getPhraseSets("first TOKEN second third");
+        final String input = "first or second third";
+
+        Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
+        assertAnalyzesTo(analyzer, input,
+                new String[] {"firstsecondthird"},
+                new int[] {0},
+                new int[] {16},
+                new int[] {1});
+    }
+
+    public void testFuzzyMatchingOptionalTokenWithMultipleWordsAfter() throws Exception {
+        final CharArraySet phrases = getPhraseSets("first TOKEN second third");
+        final String input = "first second third";
+
+        Analyzer analyzer = new AutoPhrasingAnalyzer(phrases);
+        assertAnalyzesTo(analyzer, input,
+                new String[] {"firstsecondthird"},
+                new int[] {0},
+                new int[] {16},
+                new int[] {1});
+    }
+
 }


### PR DESCRIPTION
These changes are to allow some basic fuzzy matching of phrases.  Specifically, it allows you to use the syntax "first TOKEN? third" to match "first second third", "first third", "first then third", etc, and converts them all to first_third (assuming underscore is used to replace whitespace).  Full testing hasn't been done around what happens if TOKEN? is at the start or end of a phrase, or if there are several TOKEN?'s that are separated by "real" words.  However, there is testing around adding n TOKEN? s in a row, and unit tests are present for both the indexing and the query parsing.